### PR TITLE
Fix YAML syntax for site logo

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 theme: jekyll-theme-cayman
 show_downloads: true
-logo: ![image](https://user-images.githubusercontent.com/80940234/111784229-2b46a000-88e1-11eb-92f9-cccefef79d92.png)
+logo: https://user-images.githubusercontent.com/80940234/111784229-2b46a000-88e1-11eb-92f9-cccefef79d92.png
 
 social-network-links:
   email: "k.arpan@outlook.com"


### PR DESCRIPTION
## Summary
- fix invalid image syntax in `_config.yml`

## Testing
- `pip install yamllint` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_68779a4535c08322a0125d1f64904ca7